### PR TITLE
Update dependencies, move `approx` to dev dependency and edition 2021

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,38 +3,44 @@
 version = 3
 
 [[package]]
-name = "approx"
-version = "0.3.0"
+name = "android-tzdata"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71f10b5c4946a64aad7b8cf65e3406cd3da22fc448595991d22423cf6db67b4"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "chrono"
-version = "0.4.6"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
-dependencies = [
+ "android-tzdata",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.6"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "sunrise"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,7 @@ license = "MIT"
 travis-ci = { repository = "nathan-osman/rust-sunrise" }
 
 [dependencies]
-approx = "0.3.0"
 chrono = { version = "0.4", default-features = false, features = [] }
+
+[dev-dependencies]
+approx = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ travis-ci = { repository = "nathan-osman/rust-sunrise" }
 chrono = { version = "0.4", default-features = false, features = [] }
 
 [dev-dependencies]
-approx = "0.3.0"
+approx = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/nathan-osman/rust-sunrise"
 readme = "README.md"
 categories = ["date-and-time"]
 license = "MIT"
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "nathan-osman/rust-sunrise" }

--- a/src/declination.rs
+++ b/src/declination.rs
@@ -20,13 +20,13 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-use std::f64;
+use crate::DEGREE;
 
 /// Declination calculates one of the two angles required to locate a point on
 /// the celestial sphere in the equatorial coordinate system. The ecliptic
 /// longitude parameter must be in degrees.
 pub fn declination(ecliptic_longitude: f64) -> f64 {
-    f64::asin(f64::sin(ecliptic_longitude * ::DEGREE) * 0.39779) / ::DEGREE
+    f64::asin(f64::sin(ecliptic_longitude * DEGREE) * 0.39779) / DEGREE
 }
 
 #[cfg(test)]

--- a/src/hourangle.rs
+++ b/src/hourangle.rs
@@ -20,16 +20,16 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-use std::f64;
+use crate::DEGREE;
 
 /// Calculates the second of the two angles required to locate a point on the
 /// celestial sphere in the equatorial coordinate system.
 pub fn hour_angle(latitude: f64, declination: f64) -> f64 {
-    let latitude_rad = latitude * ::DEGREE;
-    let declination_rad = declination * ::DEGREE;
+    let latitude_rad = latitude * DEGREE;
+    let declination_rad = declination * DEGREE;
     let numerator = -0.01449 - f64::sin(latitude_rad) * f64::sin(declination_rad);
     let denominator = f64::cos(latitude_rad) * f64::cos(declination_rad);
-    f64::acos(numerator / denominator) / ::DEGREE
+    f64::acos(numerator / denominator) / DEGREE
 }
 
 #[cfg(test)]

--- a/src/julian.rs
+++ b/src/julian.rs
@@ -35,7 +35,7 @@ pub fn julian_to_unix(day: f64) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use julian::UNIX_EPOCH_JULIAN_DAY;
+    use crate::julian::UNIX_EPOCH_JULIAN_DAY;
 
     #[test]
     fn test_unix_to_julian() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,15 +20,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-extern crate chrono;
-
-#[cfg(test)]
-#[macro_use]
-extern crate approx;
-
-use std::f64;
-
-const DEGREE: f64 = f64::consts::PI / 180.;
+const DEGREE: f64 = std::f64::consts::PI / 180.;
 
 mod anomaly;
 mod center;
@@ -41,4 +33,4 @@ mod perihelion;
 mod sunrise;
 mod transit;
 
-pub use sunrise::sunrise_sunset;
+pub use crate::sunrise::sunrise_sunset;

--- a/src/longitude.rs
+++ b/src/longitude.rs
@@ -20,7 +20,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-use perihelion;
+use crate::perihelion;
 
 /// Calculates the angular distance of the earth along the ecliptic.
 pub fn ecliptic_longitude(solar_anomaly: f64, equation_of_center: f64, day: f64) -> f64 {

--- a/src/noon.rs
+++ b/src/noon.rs
@@ -22,7 +22,7 @@
 
 use chrono::prelude::*;
 
-use julian::unix_to_julian;
+use crate::julian::unix_to_julian;
 
 /// Calculates the time at which the sun is at its highest altitude and returns
 /// the time as a Julian day.

--- a/src/noon.rs
+++ b/src/noon.rs
@@ -27,7 +27,12 @@ use julian::unix_to_julian;
 /// Calculates the time at which the sun is at its highest altitude and returns
 /// the time as a Julian day.
 pub fn mean_solar_noon(longitude: f64, year: i32, month: u32, day: u32) -> f64 {
-    unix_to_julian(Utc.ymd(year, month, day).and_hms(12, 0, 0).timestamp()) - longitude / 360.
+    unix_to_julian(
+        Utc.with_ymd_and_hms(year, month, day, 12, 0, 0)
+            .earliest()
+            .expect("invalid date and time")
+            .timestamp(),
+    ) - longitude / 360.
 }
 
 #[cfg(test)]

--- a/src/sunrise.rs
+++ b/src/sunrise.rs
@@ -20,14 +20,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-use anomaly::solar_mean_anomaly;
-use center::equation_of_center;
-use declination::declination;
-use hourangle::hour_angle;
-use julian::julian_to_unix;
-use longitude::ecliptic_longitude;
-use noon::mean_solar_noon;
-use transit::solar_transit;
+use crate::anomaly::solar_mean_anomaly;
+use crate::center::equation_of_center;
+use crate::declination::declination;
+use crate::hourangle::hour_angle;
+use crate::julian::julian_to_unix;
+use crate::longitude::ecliptic_longitude;
+use crate::noon::mean_solar_noon;
+use crate::transit::solar_transit;
 
 /// Calculates the sunrise and sunset times for the given location and date.
 pub fn sunrise_sunset(

--- a/src/transit.rs
+++ b/src/transit.rs
@@ -20,12 +20,12 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-use std::f64;
+use crate::DEGREE;
 
 /// Calculates the Julian day for the local true solar transit.
 pub fn solar_transit(day: f64, solar_anomaly: f64, ecliptic_longitude: f64) -> f64 {
-    day + (0.0053 * f64::sin(solar_anomaly * ::DEGREE)
-        - 0.0069 * f64::sin(2. * ecliptic_longitude * ::DEGREE))
+    day + (0.0053 * f64::sin(solar_anomaly * DEGREE)
+        - 0.0069 * f64::sin(2. * ecliptic_longitude * DEGREE))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hi! Just lurking on your crate and saw a bit of maintenance I could suggest:

 1. move `approx` to dev dependencies, as it is only used for tests (it's a single dependency crate now, congrats !)
 2. update dependencies (`cargo outdated` now report a full up to date tree)
 3. update project to edition 2021, no direct value here, it may be easier on future contributors and just required to update a few module imports :shrug: 