### PR TITLE
fix readme coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can `use` the `sunrise_sunset` function to perform the calculation:
 // Calculate times for January 1, 2016 in Toronto
 let (sunrise, sunset) = sunrise::sunrise_sunset(
     43.6532,
-    79.3832,
+    -79.3832,
     2016,
     1,
     1,


### PR DESCRIPTION
According to #5 there is a small typo in the README, a quick GMaps search appears to validate that:

![image](https://github.com/nathan-osman/rust-sunrise/assets/1173464/96e9e5cf-6a49-4e92-a7e5-34f5e1e156bd)

Fixes #5