### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Lints, Tests, Deploy
+
+on:
+  - push
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: ["stable", "beta", "nightly"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          default: true
+          profile: minimal
+          components: rustfmt, clippy
+      - name: Display rust version
+        run: |
+          rustc --version
+          cargo clippy -- --version
+          cargo fmt -- --version
+      - name: Lint
+        run: cargo clippy -- -D warnings
+        if: matrix.toolchain != 'nightly'
+      - name: Format
+        run: cargo fmt -- --check
+        if: matrix.toolchain != 'nightly'
+      - name: Tests
+        run: cargo test
+
+  deploy-rust:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal
+      - name: Test publishing
+        run: cargo publish --dry-run
+        if: github.ref != 'refs/heads/master'
+      - name: Login to crates.io
+        run: cargo login $TOKEN
+        if: github.ref == 'refs/heads/master'
+        env:
+          TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Publish to crates.io
+        run: cargo publish
+        if: github.ref == 'refs/heads/master'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: rust
-rust:
-  - stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "sunrise"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "approx",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sunrise"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Nathan Osman <nathan@quickmediasolutions.com>"]
 description = "Sunrise and sunset calculator"
 repository = "https://github.com/nathan-osman/rust-sunrise"
@@ -8,9 +8,6 @@ readme = "README.md"
 categories = ["date-and-time"]
 license = "MIT"
 edition = "2021"
-
-[badges]
-travis-ci = { repository = "nathan-osman/rust-sunrise" }
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = [] }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## sunrise
 
-[![Build Status](https://travis-ci.org/nathan-osman/rust-sunrise.svg?branch=master)](https://travis-ci.org/nathan-osman/rust-sunrise)
-[![MIT License](http://img.shields.io/badge/license-MIT-9370d8.svg?style=flat)](http://opensource.org/licenses/MIT)
+[![](https://img.shields.io/crates/l/sunrise)][license]
+[![](https://img.shields.io/crates/v/sunrise)][crate]
+[![](https://img.shields.io/docsrs/sunrise)][docs]
 
 This crate provides a function for calculating sunrise and sunset times using [this method](https://en.wikipedia.org/wiki/Sunrise_equation#Complete_calculation_on_Earth).
 
@@ -37,3 +38,7 @@ let (sunrise, sunset) = sunrise::sunrise_sunset(
     1,
 );
 ```
+
+[crate]: https://crates.io/crates/sunrise "crates.io"
+[docs]: https://docs.rs/sunrise "Documentation"
+[license]: http://opensource.org/licenses/MIT "MIT License"


### PR DESCRIPTION
Hi!

Since you released your crate 5 years ago, Travis switched to a fully pay model and Github ships with their own free competition (which runs smooth AF to be honest).

So this MR updates the CI to use the one from Github: clippy, rustfmt and auto release (MR must bump version number, but the CI should be red if it is forgotten). The only manual operation is to add a `CRATES_IO_TOKEN` token in secrets.

I've release [`surise-next`](https://crates.io/crates/sunrise-next) from my fork using the CI and test new features.

Fixes #4 