### PR TITLE
Use core functions if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.1.0
+
+- Use functions and constants from `core` instead of vendoring them
+  in "no-std" mode.
+- Implement `Display` without "std" feature enabled.
+
 ## 2.0.0
 
 - To make features additive the "no-std" feature has been replaced by

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sunrise"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Nathan Osman <nathan@quickmediasolutions.com>"]
 description = "Sunrise and sunset calculator"
 repository = "https://github.com/nathan-osman/rust-sunrise"

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -1,3 +1,5 @@
+use core::fmt::{self, Display, Formatter};
+
 /// A valid pair of geographic coordinates.
 ///
 /// See <https://en.wikipedia.org/wiki/Geographic_coordinate_system>
@@ -32,9 +34,8 @@ impl Coordinates {
     }
 }
 
-#[cfg(not(feature = "no-std"))]
-impl std::fmt::Display for Coordinates {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for Coordinates {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "({:?}, {:?})", self.lat, self.lon)
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -20,8 +20,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-use crate::math::DEGREE;
-
 /// Type of dawn or dusk computation.
 ///
 /// If you are not sure which one to pick you probably want to use `Civil`. See
@@ -49,11 +47,11 @@ pub enum DawnType {
 
 impl DawnType {
     pub(crate) fn positive_angle(&self) -> f64 {
-        match self {
-            DawnType::Civil => 6. * DEGREE,
-            DawnType::Nautical => 12. * DEGREE,
-            DawnType::Astronomical => 18. * DEGREE,
-        }
+        f64::to_radians(match self {
+            DawnType::Civil => 6.,
+            DawnType::Nautical => 12.,
+            DawnType::Astronomical => 18.,
+        })
     }
 }
 
@@ -80,7 +78,7 @@ pub enum SolarEvent {
 impl SolarEvent {
     pub(crate) fn angle(&self) -> f64 {
         match self {
-            SolarEvent::Sunrise | SolarEvent::Sunset => 5. * DEGREE / 6.,
+            SolarEvent::Sunrise | SolarEvent::Sunset => f64::to_radians(5.) / 6.,
             SolarEvent::Dusk(t) | SolarEvent::Dawn(t) => t.positive_angle(),
             SolarEvent::Elevation { elevation, .. } => *elevation,
         }

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,53 +1,14 @@
-/// Archimedes' constant (π)
-pub(crate) const PI: f64 = {
+// Calculate the non-negative remainder of `lhs mod rhs`.
+pub(crate) fn rem_euclid(lhs: f64, rhs: f64) -> f64 {
     #[cfg(not(feature = "no-std"))]
     {
-        std::f64::consts::PI
-    }
-
-    #[cfg(feature = "no-std")]
-    #[allow(clippy::approx_constant)]
-    {
-        3.141_592_653_589_793
-    }
-};
-
-/// Given an angle 𝛅 given in degrees, 𝛅 * DEGREE is the same angle in radians
-pub(crate) const DEGREE: f64 = PI / 180.;
-
-/// Computes the absolute value of `x`.
-pub(crate) fn abs(x: f64) -> f64 {
-    #[cfg(not(feature = "no-std"))]
-    {
-        f64::abs(x)
+        lhs.rem_euclid(rhs)
     }
 
     #[cfg(feature = "no-std")]
     {
-        libm::fabs(x)
-    }
-}
-
-/// Returns a number that represents the sign of `x`.
-///
-/// - `1.0` if the number is positive, `+0.0` or `INFINITY`
-/// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
-/// - NaN if the number is NaN
-pub(crate) fn signum(x: f64) -> f64 {
-    #[cfg(not(feature = "no-std"))]
-    {
-        f64::signum(x)
-    }
-
-    #[cfg(feature = "no-std")]
-    {
-        if x.is_nan() {
-            f64::NAN
-        } else if x.is_sign_positive() {
-            1.
-        } else {
-            -1.
-        }
+        let res = lhs % rhs;
+        if res < 0. { res + rhs.abs() } else { res }
     }
 }
 
@@ -86,30 +47,17 @@ use_std_or_libm!(
 
 #[cfg(test)]
 mod tests {
+    use core::f64::consts::PI;
+
     use super::*;
     use approx::assert_relative_eq;
 
-    #[allow(clippy::approx_constant)]
     #[test]
-    fn test_pi() {
-        assert_relative_eq!(PI, 3.141_592_653_589_793)
-    }
-
-    #[test]
-    fn test_abs() {
-        assert_relative_eq!(abs(0.), 0.);
-        assert_relative_eq!(abs(1.2), 1.2);
-        assert_relative_eq!(abs(-1.2), 1.2);
-        assert!(abs(f64::NAN).is_nan());
-    }
-
-    #[test]
-    fn test_signum() {
-        assert_relative_eq!(signum(1.2), 1.);
-        assert_relative_eq!(signum(-1.2), -1.);
-        assert_relative_eq!(signum(0.), 1.);
-        assert_relative_eq!(signum(-0.), -1.);
-        assert!(signum(f64::NAN).is_nan());
+    fn test_rem_euclid() {
+        assert_relative_eq!(rem_euclid(10.0, 3.0), 1.0);
+        assert_relative_eq!(rem_euclid(-8.0, 5.0), 2.0);
+        assert_relative_eq!(rem_euclid(-12.0, 5.0), 3.0);
+        assert_relative_eq!(rem_euclid(4.0, 4.0), 0.0);
     }
 
     #[test]

--- a/src/solar_equation/anomaly.rs
+++ b/src/solar_equation/anomaly.rs
@@ -20,15 +20,19 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-use crate::math::{DEGREE, PI};
+use core::f64::consts::PI;
+
+use crate::math::rem_euclid;
 
 const J2000: f64 = 2451545.;
 
 /// Calculates the angle of the sun relative to the earth for the specified
 /// Julian day.
 pub(crate) fn solar_mean_anomaly(day: f64) -> f64 {
-    let v = ((357.5291 + 0.98560028 * (day - J2000)) * DEGREE) % (2. * PI);
-    if v < 0. { v + 2. * PI } else { v }
+    rem_euclid(
+        (357.5291 + 0.98560028 * (day - J2000)).to_radians(),
+        2. * PI,
+    )
 }
 
 #[cfg(test)]
@@ -40,7 +44,7 @@ mod tests {
     fn test_prime_meridian() {
         assert_relative_eq!(
             solar_mean_anomaly(2440588.),
-            358.30683 * DEGREE,
+            f64::to_radians(358.30683),
             epsilon = 0.00001
         )
     }

--- a/src/solar_equation/center.rs
+++ b/src/solar_equation/center.rs
@@ -20,7 +20,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-use crate::math::{DEGREE, sin};
+use crate::math::sin;
 
 /// Calculates the angular difference between the position of the earth in its
 /// elliptical orbit and the position it would occupy in a circular orbit for
@@ -29,7 +29,7 @@ pub(crate) fn equation_of_center(solar_anomaly: f64) -> f64 {
     let anomaly_sin = sin(solar_anomaly);
     let anomaly_2_sin = sin(2. * solar_anomaly);
     let anomaly_3_sin = sin(3. * solar_anomaly);
-    (1.9148 * anomaly_sin + 0.02 * anomaly_2_sin + 0.0003 * anomaly_3_sin) * DEGREE
+    (1.9148 * anomaly_sin + 0.02 * anomaly_2_sin + 0.0003 * anomaly_3_sin).to_radians()
 }
 
 #[cfg(test)]
@@ -40,8 +40,8 @@ mod tests {
     #[test]
     fn test_prime_meridian() {
         assert_relative_eq!(
-            equation_of_center(358.30683 * DEGREE),
-            -0.05778 * DEGREE,
+            equation_of_center(f64::to_radians(358.30683)),
+            f64::to_radians(-0.05778),
             epsilon = 0.00001
         )
     }

--- a/src/solar_equation/declination.rs
+++ b/src/solar_equation/declination.rs
@@ -31,14 +31,13 @@ pub(crate) fn declination(ecliptic_longitude: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use crate::math::DEGREE;
     use approx::assert_relative_eq;
 
     #[test]
     fn test_prime_meridian() {
         assert_relative_eq!(
-            super::declination(281.08372 * DEGREE),
-            -22.97753 * DEGREE,
+            super::declination(f64::to_radians(281.08372)),
+            f64::to_radians(-22.97753),
             epsilon = 0.00001
         )
     }

--- a/src/solar_equation/hourangle.rs
+++ b/src/solar_equation/hourangle.rs
@@ -21,7 +21,7 @@
 // IN THE SOFTWARE.
 
 use crate::event::SolarEvent;
-use crate::math::{DEGREE, abs, acos, cos, signum, sin, sqrt};
+use crate::math::{acos, cos, sin, sqrt};
 
 /// Calculates the second of the two angles required to locate a point on the
 /// celestial sphere in the equatorial coordinate system.
@@ -31,11 +31,12 @@ pub(crate) fn hour_angle(
     altitude: f64,
     event: SolarEvent,
 ) -> f64 {
-    let latitude = latitude_deg * DEGREE;
+    let latitude = latitude_deg.to_radians();
     let denominator = cos(latitude) * cos(declination);
 
     let numerator =
-        -sin(event.angle() + (2.076 * DEGREE * signum(altitude) * sqrt(abs(altitude)) / 60.))
+        -sin(event.angle()
+            + (f64::to_radians(2.076) * altitude.signum() * sqrt(altitude.abs()) / 60.))
             - sin(latitude) * sin(declination);
 
     let sign = if event.is_morning() { -1. } else { 1. };
@@ -58,8 +59,8 @@ mod tests {
     #[test]
     fn test_prime_meridian() {
         assert_relative_eq!(
-            hour_angle(0., -22.97753 * DEGREE, 0., SolarEvent::Sunset),
-            90.90516 * DEGREE,
+            hour_angle(0., f64::to_radians(-22.97753), 0., SolarEvent::Sunset),
+            f64::to_radians(90.90516),
             epsilon = 0.00001
         );
     }
@@ -67,14 +68,14 @@ mod tests {
     #[test]
     fn test_altitude() {
         assert_relative_eq!(
-            hour_angle(0., -22.97753 * DEGREE, 100., SolarEvent::Sunset),
-            91.28098 * DEGREE,
+            hour_angle(0., f64::to_radians(-22.97753), 100., SolarEvent::Sunset),
+            f64::to_radians(91.28098),
             epsilon = 0.00001
         );
 
         assert_relative_eq!(
-            hour_angle(0., -22.97753 * DEGREE, -100., SolarEvent::Sunset),
-            90.52933 * DEGREE,
+            hour_angle(0., f64::to_radians(-22.97753), -100., SolarEvent::Sunset),
+            f64::to_radians(90.52933),
             epsilon = 0.00001
         );
     }

--- a/src/solar_equation/longitude.rs
+++ b/src/solar_equation/longitude.rs
@@ -20,8 +20,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
+use core::f64::consts::PI;
+
 use super::perihelion;
-use crate::math::PI;
 
 /// Calculates the angular distance of the earth along the ecliptic.
 pub(crate) fn ecliptic_longitude(solar_anomaly: f64, equation_of_center: f64, day: f64) -> f64 {
@@ -34,14 +35,17 @@ pub(crate) fn ecliptic_longitude(solar_anomaly: f64, equation_of_center: f64, da
 
 #[cfg(test)]
 mod tests {
-    use crate::math::DEGREE;
     use approx::assert_relative_eq;
 
     #[test]
     fn test_prime_meridian() {
         assert_relative_eq!(
-            super::ecliptic_longitude(358.30683 * DEGREE, -0.05778 * DEGREE, 2440588.),
-            281.08372 * DEGREE,
+            super::ecliptic_longitude(
+                f64::to_radians(358.30683),
+                f64::to_radians(-0.05778),
+                2440588.
+            ),
+            f64::to_radians(281.08372),
             epsilon = 0.00001
         )
     }

--- a/src/solar_equation/mod.rs
+++ b/src/solar_equation/mod.rs
@@ -28,12 +28,13 @@ mod longitude;
 mod perihelion;
 mod transit;
 
+use core::f64::consts::PI;
+
 use chrono::{DateTime, NaiveDate, Utc};
 
 use crate::Coordinates;
 use crate::event::SolarEvent;
 use crate::julian::{julian_to_unix, mean_solar_noon};
-use crate::math::PI;
 
 use self::anomaly::solar_mean_anomaly;
 use self::center::equation_of_center;

--- a/src/solar_equation/perihelion.rs
+++ b/src/solar_equation/perihelion.rs
@@ -20,11 +20,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-use crate::math::DEGREE;
-
 /// Calculates the argument of periapsis for the earth on the given Julian day.
 pub(crate) fn argument_of_perihelion(day: f64) -> f64 {
-    (102.93005 + 0.3179526 * (day - 2451545.) / 36525.) * DEGREE
+    (102.93005 + 0.3179526 * (day - 2451545.) / 36525.).to_radians()
 }
 
 #[cfg(test)]
@@ -36,7 +34,7 @@ mod tests {
     fn test_prime_meridian() {
         assert_relative_eq!(
             argument_of_perihelion(2440588.),
-            102.83467 * DEGREE,
+            f64::to_radians(102.83467),
             epsilon = 0.00001
         )
     }

--- a/src/solar_equation/transit.rs
+++ b/src/solar_equation/transit.rs
@@ -29,13 +29,16 @@ pub(crate) fn solar_transit(day: f64, solar_anomaly: f64, ecliptic_longitude: f6
 
 #[cfg(test)]
 mod tests {
-    use crate::math::DEGREE;
     use approx::assert_relative_eq;
 
     #[test]
     fn test_prime_meridian() {
         assert_relative_eq!(
-            super::solar_transit(2440588., 358.30683 * DEGREE, 281.08372 * DEGREE),
+            super::solar_transit(
+                2440588.,
+                f64::to_radians(358.30683),
+                f64::to_radians(281.08372)
+            ),
             2440588.00245,
             epsilon = 0.00001
         )

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -20,7 +20,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-use std::f64::consts::PI;
+use core::f64::consts::PI;
 
 use chrono::{DateTime, NaiveDate};
 use sunrise::{Coordinates, DawnType, SolarDay, SolarEvent};


### PR DESCRIPTION
This PR is quite opinionated so I understand if it wouldn't be merged. Mainly it does

- Use `core::f64::consts::PI` as this is also available in no-std.
- Use `f64` methods for `abs` and `signum` as these are also available in no-std.
- Factor `rem_euclid` out into a function to make it more readable and so it can be replaced at some point once [`rem_euclid` is added to core](https://github.com/rust-lang/rust/issues/137578).
- Use `f64::to_radians` instead of `* DEGREES`
- Implement `Display` even in `core`

Once [`rem_euclid` is moved to core](https://github.com/rust-lang/rust/issues/137578) in the future we could use that as well.

I'm not married to any of these changes and am more than open to remove any of them from this PR if wanted. :heart: