### PR TITLE
Fix additivity of features

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         toolchain: ["stable", "beta", "nightly"]
-        features: ["", "no-std"]
+        features: ["libm", "std"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -28,15 +28,15 @@ jobs:
           cargo clippy -- --version
           cargo fmt -- --version
       - name: Lint
-        run: cargo clippy --features "${{ matrix.features }}" -- -D warnings
+        run: cargo clippy --no-default-features --features "${{ matrix.features }}" -- -D warnings
         if: matrix.toolchain != 'nightly'
       - name: Format
         run: cargo fmt -- --check
         if: matrix.toolchain != 'nightly'
       - name: Tests
-        run: cargo test --features "${{ matrix.features }}"
+        run: cargo test --no-default-features --features "${{ matrix.features }}"
       - name: Doc Tests
-        run: cargo test --doc --features "${{ matrix.features }}"
+        run: cargo test --doc --no-default-features --features "${{ matrix.features }}"
 
   deploy-rust:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0
+
+- To make features additive the "no-std" feature has been replaced by
+  the "std" feature (default). To build for "no-std" now, set 
+  "default-features" to false, and enable the "libm" feature.
+
 ## 1.2.1
 
 - Fix _SolarEvent::Dawn_ & _SolarEvent::Dusk_ being inverted.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sunrise"
-version = "1.2.1"
+version = "2.0.0"
 authors = ["Nathan Osman <nathan@quickmediasolutions.com>"]
 description = "Sunrise and sunset calculator"
 repository = "https://github.com/nathan-osman/rust-sunrise"
@@ -13,12 +13,14 @@ edition = "2024"
 name = "sunrise"
 
 [features]
-no-std = ["dep:libm"]
+default = ["std"]
+std = []
+libm = ["dep:libm"]
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = [] }
 
-# feature: no-std
+# feature: libm
 libm = { version = "0.2", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This crate provides a function for calculating sunrise and sunset times using [this method](https://en.wikipedia.org/wiki/Sunrise_equation#Complete_calculation_on_Earth).
 
-You can enable the **no-std feature** if you need it to work in such a context, it will rely on `libm` instead.
+To work in a *no-std* environment disable the default features and enable the `libm` feature.
 
 ### Usage
 

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -32,7 +32,7 @@ impl Coordinates {
     }
 }
 
-#[cfg(not(feature = "no-std"))]
+#[cfg(feature = "std")]
 impl std::fmt::Display for Coordinates {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "({:?}, {:?})", self.lat, self.lon)
@@ -60,8 +60,9 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "no-std"))]
+    #[cfg(feature = "std")]
     fn display() {
+        use std::string::ToString;
         let coord = Coordinates::new(10.0, 36.35).unwrap();
         assert_eq!(coord.to_string(), "(10.0, 36.35)");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,13 @@
 // IN THE SOFTWARE.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(feature = "no-std", no_std)]
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(not(any(feature = "std", feature = "libm")))]
+compile_error!("either the `std` or `libm` feature is required");
 
 mod coordinates;
 mod event;

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,14 +1,19 @@
 /// Archimedes' constant (π)
 pub(crate) const PI: f64 = {
-    #[cfg(not(feature = "no-std"))]
+    #[cfg(all(not(feature = "libm"), feature = "std"))]
     {
         std::f64::consts::PI
     }
 
-    #[cfg(feature = "no-std")]
+    #[cfg(feature = "libm")]
     #[allow(clippy::approx_constant)]
     {
         3.141_592_653_589_793
+    }
+
+    #[cfg(not(any(feature = "libm", feature = "std")))]
+    {
+        core::f64::NAN
     }
 };
 
@@ -17,14 +22,20 @@ pub(crate) const DEGREE: f64 = PI / 180.;
 
 /// Computes the absolute value of `x`.
 pub(crate) fn abs(x: f64) -> f64 {
-    #[cfg(not(feature = "no-std"))]
+    #[cfg(all(not(feature = "libm"), feature = "std"))]
     {
         f64::abs(x)
     }
 
-    #[cfg(feature = "no-std")]
+    #[cfg(feature = "libm")]
     {
         libm::fabs(x)
+    }
+
+    #[cfg(not(any(feature = "libm", feature = "std")))]
+    {
+        let _ = x;
+        core::f64::NAN
     }
 }
 
@@ -34,12 +45,12 @@ pub(crate) fn abs(x: f64) -> f64 {
 /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
 /// - NaN if the number is NaN
 pub(crate) fn signum(x: f64) -> f64 {
-    #[cfg(not(feature = "no-std"))]
+    #[cfg(all(not(feature = "libm"), feature = "std"))]
     {
         f64::signum(x)
     }
 
-    #[cfg(feature = "no-std")]
+    #[cfg(feature = "libm")]
     {
         if x.is_nan() {
             f64::NAN
@@ -49,6 +60,12 @@ pub(crate) fn signum(x: f64) -> f64 {
             -1.
         }
     }
+
+    #[cfg(not(any(feature = "libm", feature = "std")))]
+    {
+        let _ = x;
+        core::f64::NAN
+    }
 }
 
 macro_rules! use_std_or_libm {
@@ -56,10 +73,15 @@ macro_rules! use_std_or_libm {
         $(
                 #[doc = $doc]
                 pub(crate) fn $func(x: f64) -> f64 {
-                    #[cfg(not(feature = "no-std"))]
+                    #[cfg(all(not(feature = "libm"), feature = "std"))]
                     { f64::$func(x) }
-                    #[cfg(feature = "no-std")]
+                    #[cfg(feature = "libm")]
                     { libm::$func(x) }
+                    #[cfg(not(any(feature = "libm", feature = "std")))]
+                    {
+                      let _ = x;
+                      core::f64::NAN
+                    }
                 }
         )+
     };


### PR DESCRIPTION
This changes the `no-std` feature around to be additive,
It has to jump through some hoops because the `compile_error!()` macro continues compilation, potentially leading to a cascade of errors.

Should fix #17 

Edit: I'm not entirely certain that the .github ci changes of just adding `--no-default-features` and whether that behaves correctly without looking at the CI output though