### PR TITLE
Implement `is_day` method

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -90,4 +90,24 @@ impl SolarEvent {
             SolarEvent::Sunrise | SolarEvent::Dawn(_) | SolarEvent::Elevation { morning: true, .. }
         )
     }
+
+    /// Using either the start or end of the day, returns the matching pair of
+    /// dawn and dusk.
+    pub(crate) fn dawn_dusk(&self) -> (SolarEvent, SolarEvent) {
+        use SolarEvent::*;
+        match self {
+            Sunrise | Sunset => (Sunrise, Sunset),
+            Dawn(dawn) | Dusk(dawn) => (Dawn(*dawn), Dusk(*dawn)),
+            Elevation { elevation, .. } => (
+                Elevation {
+                    elevation: *elevation,
+                    morning: true,
+                },
+                Elevation {
+                    elevation: *elevation,
+                    morning: false,
+                },
+            ),
+        }
+    }
 }

--- a/src/solar_equation/mod.rs
+++ b/src/solar_equation/mod.rs
@@ -30,7 +30,7 @@ mod transit;
 
 use core::f64::consts::PI;
 
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Datelike, NaiveDate, Utc};
 
 use crate::Coordinates;
 use crate::event::SolarEvent;
@@ -107,5 +107,43 @@ impl SolarDay {
         let frac = hour_angle / (2. * PI);
         let timestamp = julian_to_unix(self.solar_transit + frac);
         Some(DateTime::from_timestamp(timestamp, 0).expect("invalid result"))
+    }
+
+    /// Whether it's currently day, as defined by the [`SolarEvent`].
+    ///
+    /// Either the start or end variants of `SolarEvent` can be used as they will
+    /// be built into the matching pair of the start and end of the day.
+    ///
+    /// For days during the polar day/night, uses a simple month and hemisphere
+    /// based heuristic to determine whether it's currently day or night.
+    ///
+    /// Using a time that is not on the same date as the one used for building the
+    /// struct will give non-sensical results.
+    pub fn is_day(&self, event: SolarEvent, time: DateTime<Utc>) -> bool {
+        let (dawn, dusk) = event.dawn_dusk();
+        match (self.event_time(dawn), self.event_time(dusk)) {
+            (Some(dawn_time), Some(dusk_time)) => time >= dawn_time && time < dusk_time,
+            (None, None) => is_summer(self.lat, time.date_naive()),
+
+            // This invariant is enforced by tests, therefore it's not documented
+            // as a potential panic (as that panic would be a bug in the implementation).
+            _ => unreachable!("a day must always have both a sunset and a sunrise, or neither"),
+        }
+    }
+
+    /// Reverse of [`Self::is_day`], see it's documentation for details.
+    pub fn is_night(&self, event: SolarEvent, time: DateTime<Utc>) -> bool {
+        !self.is_day(event, time)
+    }
+}
+
+fn is_summer(lat: f64, date: NaiveDate) -> bool {
+    let is_northern_hemisphere = lat >= 0.0;
+    let summer_in_northern_hemisphere = matches!(date.month(), 4..=9);
+
+    if is_northern_hemisphere {
+        summer_in_northern_hemisphere
+    } else {
+        !summer_in_northern_hemisphere
     }
 }

--- a/tests/is_day.rs
+++ b/tests/is_day.rs
@@ -1,0 +1,207 @@
+use chrono::{DateTime, NaiveDate, TimeDelta, Utc};
+use sunrise::{Coordinates, DawnType, SolarDay, SolarEvent};
+
+fn dt(s: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(s).unwrap().to_utc()
+}
+
+fn equator_1970() -> SolarDay {
+    SolarDay::new(
+        Coordinates::new(0., 0.).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 1, 1).unwrap(),
+    )
+}
+
+#[test]
+fn typical_day_at_equator() {
+    // Sunrise=05:59:54Z, sunset=18:07:08Z (see integration_test::test_sunrise).
+    let sd = equator_1970();
+
+    // Pre-dawn night.
+    assert!(!sd.is_day(SolarEvent::Sunrise, dt("1970-01-01T03:00:00Z")));
+    assert!(sd.is_night(SolarEvent::Sunrise, dt("1970-01-01T03:00:00Z")));
+
+    // Mid-day.
+    assert!(sd.is_day(SolarEvent::Sunrise, dt("1970-01-01T12:00:00Z")));
+    assert!(!sd.is_night(SolarEvent::Sunrise, dt("1970-01-01T12:00:00Z")));
+
+    // Post-sunset night.
+    assert!(!sd.is_day(SolarEvent::Sunrise, dt("1970-01-01T21:00:00Z")));
+    assert!(sd.is_night(SolarEvent::Sunrise, dt("1970-01-01T21:00:00Z")));
+}
+
+#[test]
+fn boundary_around_sunrise() {
+    let sd = equator_1970();
+    let sunrise = sd.event_time(SolarEvent::Sunrise).unwrap();
+
+    // The interval [sunrise, sunset) is treated as day: sunrise is day, the
+    // instant before is still night.
+    assert!(!sd.is_day(SolarEvent::Sunrise, sunrise - TimeDelta::seconds(1)));
+    assert!(sd.is_day(SolarEvent::Sunrise, sunrise));
+    assert!(sd.is_day(SolarEvent::Sunrise, sunrise + TimeDelta::seconds(1)));
+}
+
+#[test]
+fn boundary_around_sunset() {
+    let sd = equator_1970();
+    let sunset = sd.event_time(SolarEvent::Sunset).unwrap();
+
+    // Sunset itself is night (half-open interval), the second before is day.
+    assert!(sd.is_day(SolarEvent::Sunrise, sunset - TimeDelta::seconds(1)));
+    assert!(!sd.is_day(SolarEvent::Sunrise, sunset));
+    assert!(!sd.is_day(SolarEvent::Sunrise, sunset + TimeDelta::seconds(1)));
+}
+
+#[test]
+fn either_pair_member_works() {
+    // Passing Sunset should produce the same result as Sunrise: dawn_dusk()
+    // normalizes to the same (Sunrise, Sunset) pair.
+    let sd = equator_1970();
+    for hour in 0..24 {
+        let t = dt(&format!("1970-01-01T{hour:02}:00:00Z"));
+        assert_eq!(
+            sd.is_day(SolarEvent::Sunrise, t),
+            sd.is_day(SolarEvent::Sunset, t),
+            "Sunrise and Sunset variants must agree at {t}",
+        );
+    }
+}
+
+#[test]
+fn civil_dawn_window_is_wider_than_sunrise_window() {
+    // At (0,0) on 2023-01-01: civil dawn=05:37:08, sunrise=~05:59 (well after),
+    // so 05:45 is night by the sunrise definition but day by the civil one.
+    let sd = SolarDay::new(
+        Coordinates::new(0., 0.).unwrap(),
+        NaiveDate::from_ymd_opt(2023, 1, 1).unwrap(),
+    );
+    let t = dt("2023-01-01T05:45:00Z");
+    assert!(sd.is_day(SolarEvent::Dawn(DawnType::Civil), t));
+    assert!(!sd.is_day(SolarEvent::Sunrise, t));
+
+    // Before civil dawn it's still night under either definition.
+    let pre = dt("2023-01-01T04:00:00Z");
+    assert!(!sd.is_day(SolarEvent::Dawn(DawnType::Civil), pre));
+    assert!(!sd.is_day(SolarEvent::Sunrise, pre));
+}
+
+#[test]
+fn is_night_negates_is_day() {
+    let sd = equator_1970();
+    for hour in 0..24 {
+        let t = dt(&format!("1970-01-01T{hour:02}:00:00Z"));
+        assert_ne!(
+            sd.is_day(SolarEvent::Sunrise, t),
+            sd.is_night(SolarEvent::Sunrise, t),
+            "is_day and is_night must disagree at {t}",
+        );
+    }
+}
+
+#[test]
+fn polar_day_north_is_always_day() {
+    // 85N on 1970-07-01: no sunrise/sunset, summer heuristic => day.
+    let sd = SolarDay::new(
+        Coordinates::new(85., 0.).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 7, 1).unwrap(),
+    );
+    assert_eq!(sd.event_time(SolarEvent::Sunrise), None);
+    for hour in [0, 6, 12, 18, 23] {
+        let t = dt(&format!("1970-07-01T{hour:02}:00:00Z"));
+        assert!(sd.is_day(SolarEvent::Sunrise, t));
+        assert!(!sd.is_night(SolarEvent::Sunrise, t));
+    }
+}
+
+#[test]
+fn polar_night_north_is_always_night() {
+    // 85N on 1970-01-01: no events, winter heuristic => night.
+    let sd = SolarDay::new(
+        Coordinates::new(85., 0.).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 1, 1).unwrap(),
+    );
+    assert_eq!(sd.event_time(SolarEvent::Sunrise), None);
+    for hour in [0, 6, 12, 18, 23] {
+        let t = dt(&format!("1970-01-01T{hour:02}:00:00Z"));
+        assert!(!sd.is_day(SolarEvent::Sunrise, t));
+        assert!(sd.is_night(SolarEvent::Sunrise, t));
+    }
+}
+
+#[test]
+fn polar_day_south_is_always_day() {
+    // 85S on 1970-01-01: southern summer => day.
+    let sd = SolarDay::new(
+        Coordinates::new(-85., 0.).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 1, 1).unwrap(),
+    );
+    assert_eq!(sd.event_time(SolarEvent::Sunrise), None);
+    for hour in [0, 6, 12, 18, 23] {
+        let t = dt(&format!("1970-01-01T{hour:02}:00:00Z"));
+        assert!(sd.is_day(SolarEvent::Sunrise, t));
+        assert!(!sd.is_night(SolarEvent::Sunrise, t));
+    }
+}
+
+#[test]
+fn polar_night_south_is_always_night() {
+    // 85S on 1970-07-01: southern winter => night.
+    let sd = SolarDay::new(
+        Coordinates::new(-85., 0.).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 7, 1).unwrap(),
+    );
+    assert_eq!(sd.event_time(SolarEvent::Sunrise), None);
+    for hour in [0, 6, 12, 18, 23] {
+        let t = dt(&format!("1970-07-01T{hour:02}:00:00Z"));
+        assert!(!sd.is_day(SolarEvent::Sunrise, t));
+        assert!(sd.is_night(SolarEvent::Sunrise, t));
+    }
+}
+
+#[test]
+fn near_24h_day_just_below_polar_cliff() {
+    // 65.726N on the 1970 summer solstice produces the longest non-polar day:
+    // sunrise just after midnight, sunset just after the following midnight,
+    // total day length ~23h56m.
+    let sd = SolarDay::new(
+        Coordinates::new(65.726, 0.).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 6, 21).unwrap(),
+    );
+    let sunrise = sd.event_time(SolarEvent::Sunrise).unwrap();
+    let sunset = sd.event_time(SolarEvent::Sunset).unwrap();
+    assert!(
+        (sunset - sunrise).num_seconds() > 23 * 3600 + 50 * 60,
+        "expected a day longer than 23h50m, got {}s",
+        (sunset - sunrise).num_seconds(),
+    );
+
+    // The narrow night window sits just after midnight, before sunrise.
+    assert!(sd.is_night(SolarEvent::Sunrise, dt("1970-06-21T00:00:00Z")));
+    assert!(sd.is_night(SolarEvent::Sunrise, sunrise - TimeDelta::seconds(1)));
+
+    // Mid-day and late evening on the computation date are both inside the day
+    // window because sunset spills onto the following calendar day.
+    assert!(sd.is_day(SolarEvent::Sunrise, sunrise));
+    assert!(sd.is_day(SolarEvent::Sunrise, dt("1970-06-21T12:00:00Z")));
+    assert!(sd.is_day(SolarEvent::Sunrise, dt("1970-06-21T23:59:00Z")));
+}
+
+#[test]
+fn just_inside_polar_day_cliff_uses_heuristic() {
+    // One step further north (65.73N) on the same solstice: the symmetric
+    // hour-angle model returns no events, so is_day falls back to the
+    // hemisphere/month heuristic -- June in the north is summer.
+    let sd = SolarDay::new(
+        Coordinates::new(65.73, 0.).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 6, 21).unwrap(),
+    );
+    assert_eq!(sd.event_time(SolarEvent::Sunrise), None);
+    assert_eq!(sd.event_time(SolarEvent::Sunset), None);
+
+    for hour in [0, 12, 23] {
+        let t = dt(&format!("1970-06-21T{hour:02}:00:00Z"));
+        assert!(sd.is_day(SolarEvent::Sunrise, t));
+        assert!(!sd.is_night(SolarEvent::Sunrise, t));
+    }
+}

--- a/tests/polar_boundary.rs
+++ b/tests/polar_boundary.rs
@@ -1,0 +1,114 @@
+use chrono::NaiveDate;
+use sunrise::{Coordinates, SolarDay, SolarEvent};
+
+// The hour-angle model is symmetric around solar noon, so the polar-day and
+// polar-night boundaries jump directly from a day with both sunrise and sunset
+// to a day with neither. The following tests pin that behaviour at 1970
+// boundaries on both hemispheres; if the algorithm is ever made asymmetric to
+// surface "rises but doesn't set" days, these will need to be updated.
+fn assert_boundary(lat: f64, before: NaiveDate, after: NaiveDate, before_has_events: bool) {
+    let coord = Coordinates::new(lat, 0.).unwrap();
+    let before_sd = SolarDay::new(coord, before);
+    let after_sd = SolarDay::new(coord, after);
+
+    assert_eq!(
+        before_sd.event_time(SolarEvent::Sunrise).is_some(),
+        before_has_events,
+        "{lat}° {before}: unexpected sunrise presence",
+    );
+    assert_eq!(
+        before_sd.event_time(SolarEvent::Sunset).is_some(),
+        before_has_events,
+        "{lat}° {before}: unexpected sunset presence",
+    );
+    assert_eq!(
+        after_sd.event_time(SolarEvent::Sunrise).is_some(),
+        !before_has_events,
+        "{lat}° {after}: unexpected sunrise presence",
+    );
+    assert_eq!(
+        after_sd.event_time(SolarEvent::Sunset).is_some(),
+        !before_has_events,
+        "{lat}° {after}: unexpected sunset presence",
+    );
+}
+
+#[test]
+fn test_polar_day_onset_north() {
+    assert_boundary(
+        78.,
+        NaiveDate::from_ymd_opt(1970, 4, 18).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 4, 19).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn test_polar_day_end_north() {
+    assert_boundary(
+        78.,
+        NaiveDate::from_ymd_opt(1970, 8, 23).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 8, 24).unwrap(),
+        false,
+    );
+}
+
+#[test]
+fn test_polar_night_onset_north() {
+    assert_boundary(
+        78.,
+        NaiveDate::from_ymd_opt(1970, 10, 26).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 10, 27).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn test_polar_night_end_north() {
+    assert_boundary(
+        78.,
+        NaiveDate::from_ymd_opt(1970, 2, 14).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 2, 15).unwrap(),
+        false,
+    );
+}
+
+#[test]
+fn test_polar_day_onset_south() {
+    assert_boundary(
+        -78.,
+        NaiveDate::from_ymd_opt(1970, 10, 22).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 10, 23).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn test_polar_day_end_south() {
+    assert_boundary(
+        -78.,
+        NaiveDate::from_ymd_opt(1970, 2, 19).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 2, 20).unwrap(),
+        false,
+    );
+}
+
+#[test]
+fn test_polar_night_onset_south() {
+    assert_boundary(
+        -78.,
+        NaiveDate::from_ymd_opt(1970, 4, 23).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 4, 24).unwrap(),
+        true,
+    );
+}
+
+#[test]
+fn test_polar_night_end_south() {
+    assert_boundary(
+        -78.,
+        NaiveDate::from_ymd_opt(1970, 8, 18).unwrap(),
+        NaiveDate::from_ymd_opt(1970, 8, 19).unwrap(),
+        false,
+    );
+}


### PR DESCRIPTION
I got confused and wasn't sure how the library behaves around the start/end of polar day/night so I ended up writing tests for it. After which I realized that I'm just confused because of timezones.

This adds a simple `is_day` and `is_night` methods which use a season and hemisphere based heuristics for polar days/nights. I believe the code should be correct and hopefully the tests also prove it to be correct.

Reusing the `SolarEvent` is perhaps a bit weird but it didn't feel correct to create a new enum, nor did it feel correct to create an additional enum just for this (and I doubt anyone will need an asymmetric definition of a day).

Fixes: #21